### PR TITLE
Fix false positive when parsing with PHP_CodeSniffer

### DIFF
--- a/lib/ASN1/Type/Primitive/Real.php
+++ b/lib/ASN1/Type/Primitive/Real.php
@@ -527,10 +527,14 @@ class Real extends Element
         $n = gmp_import($octets, 1, GMP_MSW_FIRST | GMP_BIG_ENDIAN);
         // sign bit
         $neg = gmp_testbit($n, 63);
+
+        // phpcs:disable PHPCompatibility.Miscellaneous.ValidIntegers.HexNumericStringFound
         // 11 bits of biased exponent
         $exp = (gmp_and($n, '0x7ff0000000000000') >> 52) + self::EXP_BIAS;
         // 52 bits of mantissa
         $man = gmp_and($n, '0xfffffffffffff');
+        // phpcs:enable PHPCompatibility.Miscellaneous.ValidIntegers.HexNumericStringFound
+
         // zero, ASN.1 doesn't differentiate -0 from +0
         if (self::EXP_BIAS == $exp && 0 == $man) {
             return [gmp_init(0, 10), gmp_init(0, 10)];


### PR DESCRIPTION
Hi, we run [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) (phpcs) across our codebase and one of the projects in our codebase uses your asn1 library.

phpcs is throwing a `PHPCompatibility.Miscellaneous.ValidIntegers.HexNumericStringFound` notice for a small part of your code.

After reading up about this notice here:
https://www.zend.com/php-migration/misc/hex-numeric-string

It looks like this is a false positive, so what I've done in this PR is add a rule to disable this specific notice from phpcs. See https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-parts-of-a-file

Let me know if you have any questions.