### PR TITLE
Fix 8.4 incompatibilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ php:
     - "7.3"
     - "7.4"
     - "8.0"
+    - "8.1"
+    - "8.2"
+    - "8.3"
+    - "8.4"
 before_script:
     - "composer install"
     - "composer require php-coveralls/php-coveralls"

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,9 @@
     "require-dev": {
         "phpunit/phpunit": "^8.1"
     },
+    "conflict": {
+        "php": "8.2.26 || 8.3.14 || 8.4.1"
+    },
     "autoload": {
         "psr-4": {
             "Sop\\ASN1\\": "lib/ASN1/"

--- a/lib/ASN1/Component/Identifier.php
+++ b/lib/ASN1/Component/Identifier.php
@@ -85,7 +85,7 @@ class Identifier implements Encodable
      *
      * @return self
      */
-    public static function fromDER(string $data, int &$offset = null): Identifier
+    public static function fromDER(string $data, ?int &$offset = null): Identifier
     {
         $idx = $offset ?? 0;
         $datalen = strlen($data);

--- a/lib/ASN1/Component/Length.php
+++ b/lib/ASN1/Component/Length.php
@@ -98,7 +98,7 @@ class Length implements Encodable
      * @throws DecodeException If decoding or expectation fails
      */
     public static function expectFromDER(string $data, int &$offset,
-        int $expected = null): self
+        ?int $expected = null): self
     {
         $idx = $offset;
         $length = self::fromDER($data, $idx);

--- a/lib/ASN1/Component/Length.php
+++ b/lib/ASN1/Component/Length.php
@@ -50,7 +50,7 @@ class Length implements Encodable
      *
      * @throws DecodeException If decoding fails
      */
-    public static function fromDER(string $data, int &$offset = null): self
+    public static function fromDER(string $data, ?int &$offset = null): self
     {
         $idx = $offset ?? 0;
         $datalen = strlen($data);

--- a/lib/ASN1/Element.php
+++ b/lib/ASN1/Element.php
@@ -198,7 +198,7 @@ abstract class Element implements ElementBase
      * @throws \UnexpectedValueException If called in the context of an expected
      *                                   type, but decoding yields another type
      */
-    public static function fromDER(string $data, int &$offset = null): ElementBase
+    public static function fromDER(string $data, ?int &$offset = null): ElementBase
     {
         $idx = $offset ?? 0;
         // decode identifier


### PR DESCRIPTION
8.4 starts issuing warnings about implicit nullable parameters, e.g. `int $foo = null` should be `?int $foo = null`. This change corrects the signatures for compatibility.

This also relatedly blocks versions of PHP with a regression in GMP, demonstrated at https://3v4l.org/lnhXp